### PR TITLE
docs: README root + data/raw + data/clean

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,39 @@
-# 📊 Titolo del progetto - TBD
+# Bilancio dello Stato — Serie storica saldi e spese per missione (2003–2024)
 
 ## Domanda civica
-(Una sola frase, chiara, misurabile)
+
+La spesa corrente comprime strutturalmente gli investimenti, o il pattern cambia per missione e programma?
 
 ## Perché questo progetto
-(2–3 righe: perché questa domanda è rilevante ora)
+
+Negli ultimi vent'anni lo Stato italiano ha chiuso ogni esercizio in deficit, con la spesa corrente che assorbe in media il 64% del totale. La spesa in conto capitale si è fermata all'8.5%, toccando il minimo del 4.9% nel 2015. L'avanzo primario è stato positivo in 16 anni su 22, ma gli interessi sul debito (75–90 mld/anno) lo hanno azzerato sistematicamente.
+
+Questo progetto verifica se la compressione degli investimenti sia strutturale o congiunturale, analizzando la serie storica dei saldi aggregati e disaggregando la spesa per missione e programma.
 
 ## Ruoli
-- Project Lead:
-- Data:
-- Metodo:
-- Viz:
-- QA:
-- Docs:
+
+* Project Lead: [Gabri](https://github.com/Gabrymi93)
+* Data: [Matteo](https://github.com/matteocavo) · [Gabri](https://github.com/Gabrymi93)
+* Ricerca semantica CERES: [Andrea](https://github.com/AndreaBozzo)
+* Viz: [Matteo](https://github.com/matteocavo)
+* QA: [Gabri](https://github.com/Gabrymi93)
+* Docs: [Matteo](https://github.com/matteocavo)
 
 ## Dataset utilizzati
-- Fonte: OpenBDAP
-- Dataset: [Rendiconto Pubblicato - Serie storica - Saldi](https://bdap-opendata.rgs.mef.gov.it/content/rendiconto-pubblicato-serie-storica-saldi)
-- Periodo: 2003-2024
-- Livello: Anno
+
+* Fonte: [OpenBDAP — Rendiconto Pubblicato, Serie storica Saldi](https://bdap-opendata.rgs.mef.gov.it/content/rendiconto-pubblicato-serie-storica-saldi)
+* Fonte: [OpenBDAP — Spese per Missione, Programma e Macroaggregato](https://bdap-opendata.rgs.mef.gov.it/content/rendiconto-pubblicato-serie-storica-spese-aggregato-missione-programma-e-macroaggregato)
+* Periodo: 2003–2024 (saldi) · 2008–2024 (missioni)
+* Livello: Nazionale — Stato centrale
 
 ## Output pubblico
-- Tipo: (dashboard / report / pagina)
-- Link: (quando disponibile)
+
+* Tipo: dashboard / discussions
+* Link: (quando disponibile)
 
 ## Stato progetto
-🟢 Attivo | 🟡 In revisione | 🔴 Bloccato | ✅ Chiuso
+
+🟢 Attivo
 
 ## Come si contribuisce
 
@@ -37,4 +45,6 @@
 Dettagli in `WORKFLOW.md`.
 
 ## Link utili
-- [Metodo DataCivicLab](https://github.com/dataciviclab/dataciviclab/blob/main/METHOD.md)
+
+* [Avanzamento progetto](https://github.com/orgs/dataciviclab/projects/5)
+* [Metodo DataCivicLab](https://github.com/dataciviclab/dataciviclab/blob/main/METHOD.md)

--- a/data/clean/README.md
+++ b/data/clean/README.md
@@ -1,101 +1,140 @@
-# /data/clean - Dati puliti
+# 🧹 /data/clean — Dati puliti
 
-Questa cartella documenta il layer CLEAN del dataset OpenBDAP "Rendiconto pubblicato - Serie storica - Saldi".
+Il layer CLEAN normalizza i dati RAW senza alterarne il contenuto semantico.
+Input: CSV da `data/raw/`. Output: Parquet + metadata su Google Drive.
 
-Notebook che genera il clean:
-[02_raw_clean.ipynb](https://github.com/dataciviclab/openbdap-saldi-storico-stato/blob/20e49144f32db9a4a727e59b861f9935ef9cf5cd/notebooks/02_raw_clean.ipynb)
+---
 
-## Obiettivo del CLEAN
+## 🔗 Notebook di trasformazione
 
-Produrre una serie storica annuale coerente e pronta per analisi, senza alterare il significato dei valori di business.
+📓 [`02_raw_clean.ipynb`](../../notebooks/02_raw_clean.ipynb)
 
-Il passaggio RAW -> CLEAN applica solo:
-- parsing CSV
-- rename colonne in `snake_case`
-- mapping semantico dei nomi colonna attesi
-- cast dei tipi
-- export parquet
-- metadata di tracciabilita
+---
 
-Non vengono applicati:
-- ricalcoli contabili
-- correzioni manuali dei saldi
-- normalizzazioni economiche
-- interpretazioni del dato
+## 📂 Struttura Drive (CLEAN)
 
-## Struttura output
+```
+MyDrive/DataCivicLab/data/clean/
+├── openbdap_rendiconto_saldi_storico/
+│   └── <RUN_ID>/
+│       ├── saldi_storico.parquet
+│       ├── columns_mapping_raw_to_clean.json
+│       ├── profile_clean.json
+│       ├── validate_clean.json
+│       ├── data_dictionary.json
+│       └── clean_manifest.json
+└── openbdap_rendiconto_spese_missioni/
+    └── <RUN_ID>/
+        ├── spese_missioni.parquet
+        ├── columns_mapping_raw_to_clean.json
+        ├── profile_clean.json
+        ├── validate_clean.json
+        ├── data_dictionary.json
+        └── clean_manifest.json
+```
 
-Ogni esecuzione salva i file in:
+🔗 [Cartella Drive — CLEAN](https://drive.google.com/drive/folders/1JGJpf6jeFDzpgZRgfXoBShBt3zP9kQVg?usp=sharing)
 
-`data/clean/openbdap_rendiconto_saldi_storico/<RUN_ID>/`
+---
 
-Output attesi:
-- `saldi_storico.parquet`
-- `columns_mapping_raw_to_clean.json`
-- `profile_clean.json`
-- `clean_manifest.json`
+## 🔄 Policy di trasformazione
 
-## Schema logico atteso
+Le stesse regole si applicano a entrambi i dataset.
 
-Chiave:
-- `esercizio_finanziario` -> `INTEGER`
+### Null policy
+I seguenti valori vengono convertiti a `NULL`:
+`""` · `" "` · `"n.d."` · `"nd"` · `"N.D."` · `"null"` · `"NULL"`
 
-Misure principali:
-- `risparmio_pubblico` -> `DOUBLE`
-- `saldo_netto_da_finanziare` -> `DOUBLE`
-- `indebitamento_netto` -> `DOUBLE`
-- `ricorso_al_mercato` -> `DOUBLE`
-- `avanzo_primario` -> `DOUBLE`
+### Parsing numerico
+- `,` → `.` (separatore decimale)
+- `-` mantenuto come segno meno (non è null)
+- `%` → valore diviso 100
+- Cast finale: `TRY_CAST AS DOUBLE` (fallisce silenziosamente a NULL)
 
-Aggregati di spesa:
-- `spese_correnti` -> `DOUBLE`
-- `spese_per_interessi` -> `DOUBLE`
-- `spese_in_conto_capitale` -> `DOUBLE`
-- `spese_acquisizione_attivita_finanziarie` -> `DOUBLE`
-- `spese_per_rimborso_prestiti` -> `DOUBLE`
-- `spese_complessive` -> `DOUBLE`
-- `spese_finali` -> `DOUBLE`
-- `spese_finali_netto_att_fin` -> `DOUBLE`
+### Nomi colonne
+- Rinomina semantica esplicita via `SEMANTIC_MAP` (vedi `columns_mapping_raw_to_clean.json`)
+- Fallback automatico a `snake_case` per colonne non mappate
 
-Aggregati di entrata:
-- `entrate_tributarie` -> `DOUBLE`
-- `entrate_extra_tributarie` -> `DOUBLE`
-- `entrate_alienazioni_patrimoniali_e_riscossioni` -> `DOUBLE`
-- `riscossione_crediti` -> `DOUBLE`
-- `entrate_accensione_prestiti` -> `DOUBLE`
-- `entrate_finali` -> `DOUBLE`
-- `entrate_fin_netto_riscossione_crediti` -> `DOUBLE`
-- `entrate_correnti` -> `DOUBLE`
+### Cosa NON viene fatto
+- Nessun ricalcolo o modifica semantica dei valori economici
+- Nessuna aggregazione o join
+- Nessuna imputazione dei null
 
-Colonne non riconosciute dal mapping:
-- fallback a `snake_case`
-- cast conservativo a `VARCHAR`, salvo gestione esplicita nel notebook
+---
 
-## Policy di parsing
+## 📊 Dataset 1 — Saldi storici
 
-Parsing numerico:
-- trim degli spazi
-- supporto a valori con `,` o `.`
-- cast finale a `DOUBLE`
+**File output:** `saldi_storico.parquet`
+**Chiave:** `esercizio_finanziario` (unica per anno)
+**Righe attese:** 22 (2003–2024)
 
-Valori speciali:
-- `NULL` se il valore e vuoto o non parseabile
-- nessuna sostituzione arbitraria di valori economici
+### Schema colonne
 
-Policy generale:
-- i valori vengono solo convertiti di tipo
-- il significato economico resta invariato rispetto al RAW
+| Colonna CLEAN | Tipo | Colonna RAW |
+|---|---|---|
+| `esercizio_finanziario` | INTEGER | `ANNO` |
+| `risparmio_pubblico` | DOUBLE | `RISPARMIO_PUBBLICO` |
+| `saldo_netto_da_finanziare` | DOUBLE | `SALDO_NETTO` |
+| `indebitamento_netto` | DOUBLE | `INDEBITAMENTO_NETTO` |
+| `ricorso_al_mercato` | DOUBLE | `RICORSO_MERCATO` |
+| `avanzo_primario` | DOUBLE | `AVANZO_PRIMARIO` |
+| `spese_correnti` | DOUBLE | `SPESE_CORRENTI` |
+| `spese_per_interessi` | DOUBLE | `SPESE_INTERESSI` |
+| `spese_in_conto_capitale` | DOUBLE | `SPESE_CONTO_CAPITALE` |
+| `spese_acquisizione_attivita_finanziarie` | DOUBLE | `SPESE_ACQ_ATT_FINE` |
+| `spese_per_rimborso_prestiti` | DOUBLE | `SPESE_RIMBORSO_PRESTITI` |
+| `spese_complessive` | DOUBLE | `SPESE_COMPLESSIVE` |
+| `spese_finali` | DOUBLE | `SPESE_FINALI` |
+| `spese_finali_netto_att_fin` | DOUBLE | `SPESE_FIN_NETTO_ATT_FIN` |
+| `entrate_tributarie` | DOUBLE | `ENTRATE_TRIBUTARIE` |
+| `entrate_extra_tributarie` | DOUBLE | `ENTRATE_EXTRA_TRIBUTARIE` |
+| `entrate_alienazioni_patrimoniali_e_riscossioni` | DOUBLE | `ENTR_ALIEN_PATR_RISCOS` |
+| `riscossione_crediti` | DOUBLE | `RISCOSSIONE_CREDITI` |
+| `entrate_accensione_prestiti` | DOUBLE | `ENTR_ACCENSIONE_PRESTITI` |
+| `entrate_finali` | DOUBLE | `ENTRATE_FINALI` |
+| `entrate_fin_netto_riscossione_crediti` | DOUBLE | `ENTR_FIN_NETTO_RISCO_CRED` |
+| `entrate_correnti` | DOUBLE | `ENTRATE_CORRENTI` |
 
-## Controlli qualita minimi consigliati
+---
 
-- numero righe atteso coerente con la serie annuale
-- presenza della colonna `esercizio_finanziario`
-- assenza di duplicati sulla chiave anno
-- presenza delle colonne core attese
-- controllo null per colonna
+## 📊 Dataset 2 — Spese per Missione, Programma e Macroaggregato
 
-## Metadata salvati
+**File output:** `spese_missioni.parquet`
+**Chiave composta:** `(esercizio_finanziario, codice_missione, codice_programma, codice_macroaggregato)`
+**Righe attese:** ~2.000+ (2008–2024 × missioni × programmi × macroaggregati)
+**Encoding RAW originale:** `latin-1`
 
-- `columns_mapping_raw_to_clean.json`: mapping colonne RAW -> CLEAN
-- `profile_clean.json`: dimensioni, colonne, null, sample righe
-- `clean_manifest.json`: input/output e hash SHA256
+### Schema colonne
+
+| Colonna CLEAN | Tipo | Colonna RAW |
+|---|---|---|
+| `esercizio_finanziario` | INTEGER | `Esercizio Finanziario` |
+| `codice_missione` | INTEGER | `Codice Missione` |
+| `missione` | VARCHAR | `Missione` |
+| `codice_programma` | INTEGER | `Codice Programma` |
+| `programma` | VARCHAR | `Programma` |
+| `codice_macroaggregato` | INTEGER | `Codice Macroaggregato` |
+| `macroaggregato` | VARCHAR | `Macroaggregato` |
+| `previsioni_definitive_cp` | DOUBLE | `Previsioni Definitive CP` |
+| `previsioni_definitive_cs` | DOUBLE | `Previsioni Definitive CS` |
+
+> ⚠️ Null attesi: ~90 righe in `previsioni_definitive_cp` e `previsioni_definitive_cs` (anni iniziali senza dato).
+
+---
+
+## ✅ Validazioni automatiche
+
+Eseguite dal notebook al termine di ogni run:
+
+**Dataset 1 (Saldi)**
+- `row_count_ge_1` — dataset non vuoto
+- `required_columns_present` — colonne obbligatorie presenti
+- `unique_esercizio_finanziario` — nessun duplicato per anno
+- `year_bounds_present` — range anni valorizzato
+
+**Dataset 2 (Missioni)**
+- `row_count_ge_min` — almeno 100 righe
+- `required_columns_present` — colonne obbligatorie presenti
+- `unique_composite_key` — nessun duplicato sulla chiave composta
+- `year_bounds_present` — range anni valorizzato
+- `null_check_previsioni_definitive_cp/cs` — null entro soglia attesa (≤ 200)

--- a/data/raw/README.md
+++ b/data/raw/README.md
@@ -1,69 +1,127 @@
-# 📥 /data/raw – Dati originali (documentazione)
+# 📥 /data/raw — Dati originali
+
+Il layer RAW è **intoccabile**: replica esattamente la fonte ufficiale senza alcuna trasformazione.
+Ogni esecuzione crea uno snapshot versionato con `RUN_ID` timestamp UTC.
 
 ---
 
 ## 🔗 Notebook di ingestione
 
-📓 [01_source_raw.ipynb](../../notebooks/01_source_raw.ipynb)
+📓 [`01_source_raw.ipynb`](../../notebooks/01_source_raw.ipynb)
 
-Il notebook gestisce:
-- download del CSV ufficiale OpenBDAP
-- salvataggio snapshot versionato
-- calcolo SHA256
+Il notebook gestisce per entrambi i dataset:
+- download del CSV ufficiale OpenBDAP via `requests` (streaming + chunked)
+- validazione del primo chunk (no HTML di errore)
+- salvataggio snapshot versionato su Google Drive
+- calcolo SHA256 per integrità
 - generazione `run_manifest.json`
 - generazione `profile_basic.json`
 
 ---
 
-## 🔗 Link Drive (raw)
+## 📂 Struttura Drive (RAW)
 
-[Cartella Drive – RAW OpenBDAP Saldi](https://drive.google.com/drive/folders/1wkoZrfr5c_vNJWP2sVZiZECPEoJpJrz6?usp=drive_link)
+```
+MyDrive/DataCivicLab/data/raw/
+├── openbdap_rendiconto_saldi_storico/
+│   └── <RUN_ID>/
+│       ├── rendiconto_pubblicato_serie_storica_saldi_raw.csv
+│       ├── run_manifest.json
+│       └── profile_basic.json
+└── openbdap_rendiconto_spese_missioni/
+    └── <RUN_ID>/
+        ├── rendiconto_pubblicato_spese_missioni_raw.csv
+        ├── run_manifest.json
+        └── profile_basic.json
+```
 
-Snapshot esempio:
-[OpenBDAP Saldi — RUN 20260226_194139](https://drive.google.com/drive/folders/1Ye8u_hUVl36NvCkXlU7Iqau5XIEQgRoZ?usp=sharing)
-
----
-
-## 📚 Dataset documentato
-
-**Nome dataset:**  
-Rendiconto pubblicato — Serie storica — Saldi
-
-**Fonte ufficiale:**  
-https://bdap-opendata.rgs.mef.gov.it/content/rendiconto-pubblicato-serie-storica-saldi
-
-**Formato:** CSV (delimiter `;`, valori tra doppi apici)
-
-**Periodo coperto:** 2003–2024  
-**Livello:** Anno  
-**Numero righe:** 23 (una per anno + header)
-
-### Campi principali
-
-- ANNO  
-- RISPARMIO_PUBBLICO  
-- SALDO_NETTO  
-- INDEBITAMENTO_NETTO  
-- RICORSO_MERCATO  
-- AVANZO_PRIMARIO  
-- SPESE_CORRENTI  
-- SPESE_INTERESSI  
-- SPESE_CONTO_CAPITALE  
-- SPESE_ACQ_ATT_FINE  
-- SPESE_RIMBORSO_PRESTITI  
+🔗 [Cartella Drive — RAW Saldi](https://drive.google.com/drive/folders/1wkoZrfr5c_vNJWP2sVZiZECPEoJpJrz6?usp=drive_link)
 
 ---
 
-## 📌 Checklist
-- [x] pubblico, citabile, verificabile  
-- [x] fonte ufficiale (RGS – OpenBDAP)  
-- [x] frequenza aggiornamento: annuale  
+## 📚 Dataset 1 — Saldi storici
+
+**Nome:** Rendiconto Pubblicato — Serie storica — Saldi
+**Fonte:** [OpenBDAP (RGS)](https://bdap-opendata.rgs.mef.gov.it/content/rendiconto-pubblicato-serie-storica-saldi)
+**Formato:** CSV · delimitatore `;` · encoding `UTF-8`
+**Periodo:** 2003–2024 · **Livello:** Anno · **Righe:** 23
+
+### Campi
+
+| Campo RAW | Descrizione |
+|---|---|
+| `ANNO` | Anno di esercizio finanziario |
+| `RISPARMIO_PUBBLICO` | Risparmio pubblico |
+| `SALDO_NETTO` | Saldo netto da finanziare |
+| `INDEBITAMENTO_NETTO` | Indebitamento netto |
+| `RICORSO_MERCATO` | Ricorso al mercato |
+| `AVANZO_PRIMARIO` | Avanzo primario |
+| `SPESE_CORRENTI` | Spese correnti |
+| `SPESE_INTERESSI` | Spese per interessi |
+| `SPESE_CONTO_CAPITALE` | Spese in conto capitale |
+| `SPESE_ACQ_ATT_FINE` | Spese acquisizione attività finanziarie |
+| `SPESE_RIMBORSO_PRESTITI` | Spese per rimborso prestiti |
+| `SPESE_COMPLESSIVE` | Spese complessive |
+| `SPESE_FINALI` | Spese finali |
+| `SPESE_FIN_NETTO_ATT_FIN` | Spese finali netto attività finanziarie |
+| `ENTRATE_TRIBUTARIE` | Entrate tributarie |
+| `ENTRATE_EXTRA_TRIBUTARIE` | Entrate extra-tributarie |
+| `ENTR_ALIEN_PATR_RISCOS` | Entrate alienazioni patrimoniali e riscossioni |
+| `RISCOSSIONE_CREDITI` | Riscossione crediti |
+| `ENTR_ACCENSIONE_PRESTITI` | Entrate accensione prestiti |
+| `ENTRATE_FINALI` | Entrate finali |
+| `ENTR_FIN_NETTO_RISCO_CRED` | Entrate finali netto riscossione crediti |
+| `ENTRATE_CORRENTI` | Entrate correnti |
 
 ---
 
-## 📝 Note
+## 📚 Dataset 2 — Spese per Missione, Programma e Macroaggregato
 
-- Il livello RAW è salvato come snapshot versionato (`<RUN_ID>`).
-- Nessuna trasformazione viene applicata in questa fase.
-- Integrità garantita tramite SHA256 registrato in `run_manifest.json`.
-- Qualsiasi trasformazione verrà effettuata nel notebook successivo `02_clean_transform.ipynb`.
+**Nome:** Rendiconto Pubblicato — Serie storica — Spese Aggregato per Missione, Programma e Macroaggregato
+**Fonte:** [OpenBDAP (RGS)](https://bdap-opendata.rgs.mef.gov.it/content/rendiconto-pubblicato-serie-storica-spese-aggregato-missione-programma-e-macroaggregato)
+**Formato:** CSV · delimitatore `;` · encoding `latin-1`
+**Periodo:** 2008–2024 · **Livello:** Anno / Missione / Programma / Macroaggregato
+
+### Campi
+
+| Campo RAW | Descrizione |
+|---|---|
+| `Esercizio Finanziario` | Anno di esercizio |
+| `Codice Missione` | Codice numerico della missione |
+| `Missione` | Denominazione della missione di spesa |
+| `Codice Programma` | Codice numerico del programma |
+| `Programma` | Denominazione del programma |
+| `Codice Macroaggregato` | Codice numerico del macroaggregato |
+| `Macroaggregato` | Denominazione (es. FUNZIONAMENTO, INTERVENTI) |
+| `Previsioni Definitive CP` | Previsioni definitive di competenza |
+| `Previsioni Definitive CS` | Previsioni definitive di cassa |
+
+> ⚠️ Encoding `latin-1`: i nomi delle missioni contengono caratteri accentati italiani.
+
+---
+
+## 🔐 Integrità e tracciabilità
+
+Ogni run produce un `run_manifest.json` con:
+
+```json
+{
+  "run_id": "20260226_194139",
+  "downloaded_at_utc": "2026-02-26T19:41:39+00:00",
+  "raw_file": {
+    "bytes": 3421,
+    "sha256": "abc123...",
+    "content_type": "text/csv"
+  }
+}
+```
+
+---
+
+## 📌 Checklist fonte
+
+- [x] Pubblica, citabile, verificabile
+- [x] Fonte ufficiale (RGS — Ragioneria Generale dello Stato)
+- [x] Frequenza aggiornamento: annuale
+- [x] Nessuna trasformazione applicata al layer RAW
+- [x] Integrità garantita da SHA256 in `run_manifest.json`


### PR DESCRIPTION
## Sintesi
Aggiorna i tre README principali del repository: root, layer RAW e layer CLEAN. Documenta entrambi i dataset (Saldi 2003–2024 e Spese per Missione 2008–2024), la pipeline di ingestione, le policy di trasformazione e le validazioni automatiche.

## Contesto collegato
Related to #8
Related to #1

## Cosa cambia
- `README.md` — titolo, domanda civica, ruoli, entrambe le fonti OpenBDAP, stato progetto
- `data/raw/README.md` — documenta Dataset 1 (Saldi) e Dataset 2 (Missioni) con schema campi, struttura Drive, integrità SHA256 e checklist fonte
- `data/clean/README.md` — schema colonne RAW→CLEAN per entrambi i dataset, policy null/parsing/snake_case, validazioni automatiche del notebook

## Impatto
- [x] Documentazione o testi
- [ ] Policy GitHub o template
- [ ] Codice o automazioni
- [ ] Pipeline dati o trasformazioni
- [ ] Contenuti o metadati di dataset
- [ ] Nessun impatto visibile per chi usa il repository

## Verifica
Revisione manuale dei tre file. Nessun codice modificato.

## Controlli
- [x] Questa PR è nel repository giusto
- [x] Ho collegato issue o discussion quando serve
- [x] Ho verificato l'impatto su documentazione, codice o dati
- [x] Ho aggiornato solo quello che era davvero necessario

## Note per chi revisiona
Manca ancora `data/mart/README.md` che verrà aggiunto in una PR separata. Verificare che i link Drive in `data/raw/README.md` e `data/clean/README.md` siano corretti prima del merge.
